### PR TITLE
Use setuptools-scm, and derive the version number from Git tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,16 +7,9 @@ here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, "README.rst"), "rt", encoding="utf8") as f:
     readme = f.read()
 
-about = {}
-with io.open(
-    os.path.join(here, "tutors3", "__about__.py"), "rt", encoding="utf-8"
-) as f:
-    exec(f.read(), about)
-
-
 setup(
     name="tutor-s3",
-    version=about["__version__"],
+    use_scm_version=True,
     url="https://github.com/hastexo/tutor-s3/",
     project_urls={
         "Code": "https://github.com/hastexo/tutor-s3",
@@ -31,6 +24,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.8",
     install_requires=["tutor"],
+    setup_requires=["setuptools-scm"],
     entry_points={"tutor.plugin.v0": ["s3 = tutors3.plugin"]},
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tutors3/__about__.py
+++ b/tutors3/__about__.py
@@ -1,1 +1,8 @@
-__version__ = "0.1"
+import pkg_resources
+# __version__ attribute as suggested by (deferred) PEP 396:
+# https://www.python.org/dev/peps/pep-0396/
+#
+# Single-source package definition as suggested (among several
+# options) by:
+# https://packaging.python.org/guides/single-sourcing-package-version/
+__version__ = pkg_resources.get_distribution('tutor-s3').version


### PR DESCRIPTION
Rather than hard-coding the version number in `__about__.py`, derive the version number from a Git tag with `setuptools-scm` (and then set the version number in `__about__.py` from that).